### PR TITLE
Increased compatibility to other windows api plugins

### DIFF
--- a/pidgin-win7.h
+++ b/pidgin-win7.h
@@ -44,7 +44,7 @@
 #define PIDGIN_PLUGIN_TYPE PIDGIN_UI
 #endif
 
-#define PIDGIN_WIN7_APPID L"Pidgin.Win7Plugin"
+#define PIDGIN_WIN7_APPID L"Pidgin.Pidgin"
 
 #ifndef __RPC__in
 #define __RPC__in


### PR DESCRIPTION
See https://github.com/ChristianGalla/PidginWinToastNotifications/issues/4

Unfortunately, I have not tested if this change works because I am unable to compile the plugin.
I am getting redefinition errors and undefined references.
I think this is because the plugin redefines some win32 api functions that are available in newer versions of mingw and calls other functions that mingw does not provide.

I think you once mentioned that you patched some mingw libraries? 
How about switching to dynamic linking and load the windows dlls at runtime, so the plugin can be compiled even if mingw's libraries are outdated or incomplete?